### PR TITLE
Corrects missing alt_covers_chest var

### DIFF
--- a/code/modules/clothing/under/jobs/civilian.dm
+++ b/code/modules/clothing/under/jobs/civilian.dm
@@ -32,6 +32,7 @@
 	item_color = "cargo"
 	body_parts_covered = CHEST|GROIN|ARMS
 	mutantrace_variation = MUTANTRACE_VARIATION
+	alt_covers_chest = TRUE
 
 
 /obj/item/clothing/under/rank/chaplain


### PR DESCRIPTION
Adjusting the appearance of the cargotech jumpsuit only rolls the sleeves up, the chest is still covered.